### PR TITLE
up app.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -78,8 +78,20 @@ def PypiAttData():
 
 def PypiInfoGeral():
     """
-    Função para criar os selectbox de data(Ano) | Ocorrência.
+    Função para criar os selectbox de | Ocorrência.
     """
+    # CSS para reduzir o tamanho do selectbox
+    st.markdown(
+        """
+            <style>
+            #T1 {
+                max-width: 300px;
+            }
+            </style>
+            """,
+        unsafe_allow_html=True,
+    )
+
     # Colunas do Selectbox
     (col1,) = st.columns([0.1])
 


### PR DESCRIPTION
## Resumo por Sourcery

Restringir a largura da caixa de seleção em PypiInfoGeral e ajustar sua docstring

Melhorias:
- Adicionar estilo CSS para limitar a largura máxima da caixa de seleção a 300px
- Atualizar a docstring de PypiInfoGeral para remover a referência obsoleta a 'Ano'

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Constrain the width of the selectbox in PypiInfoGeral and adjust its docstring

Enhancements:
- Add CSS styling to limit the selectbox max-width to 300px
- Update PypiInfoGeral docstring to remove obsolete 'Ano' reference

</details>